### PR TITLE
Clear inputs on finished multiplayer controllers

### DIFF
--- a/lua/lib/nxtas.lua
+++ b/lua/lib/nxtas.lua
@@ -188,6 +188,8 @@ function nxtas.runMultiplayerTas(filenames, controllers)
                         readFiles[c] = false
                     end
                 end
+            else
+                clearInputs(controllers[c])
             end
         end
         EventWaitMax(vsync_event)


### PR DESCRIPTION
Current behaviour:
After the script of Player 2 has ended, its last input will continuously be used as input until the whole playback ends.

New behaviour:
After the script of Player 2 has ended, no further inputs will be done from that controller.

WARNING:
These changes are entirely untested. I never programmed in LUA before and don't have a build setup for it to test these changes, and especially didn't run it on hardware. Please test before merging.